### PR TITLE
Reduce binary size of app.wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ bundle exec rbwasm build -o dist/ruby.wasm
 Pack gibier2 source code into ruby.wasm
 ```sh
 bundle exec rbwasm pack ../dist/ruby.wasm --dir ./src::/src -o ../dist/app.wasm
+rake compress
 ```
 
 Setup server-side

--- a/config.ru
+++ b/config.ru
@@ -31,6 +31,9 @@ app = DRb::WebSocket::RackApp.new(Proc.new {|env|
   when '/dist/app.wasm'
     js = File.read('./dist/app.wasm')
     [200, { 'content-type' => 'application/wasm' }, [js] ]
+  when '/dist/app.wasm.gz'
+    js = File.read('./dist/app.wasm.gz')
+    [200, { 'content-type' => 'application/gzip' }, [js] ]
   when '/css/highlight.css'
     css = Rouge::Themes::Base16.mode(:dark).render(scope: '.highlight')
     [200, { 'content-type' => 'text/css' }, [css] ]

--- a/index.html
+++ b/index.html
@@ -21,7 +21,10 @@
     </div>
     <script type="module">
       import { DefaultRubyVM } from "https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.7.1/dist/browser/+esm";
-      const response = await fetch("/dist/app.wasm");
+      const response = fetch("/dist/app.wasm.gz")
+        .then(response => response.blob())
+        .then(blob => blob.stream().pipeThrough(new DecompressionStream('gzip')))
+        .then(stream => new Response(stream, { headers: { 'Content-Type': 'application/wasm' } }))
       const module = await WebAssembly.compileStreaming(response);
       const { vm } = await DefaultRubyVM(module);
 

--- a/static/index.html
+++ b/static/index.html
@@ -21,7 +21,10 @@
     </div>
     <script type="module">
       import { DefaultRubyVM } from "https://cdn.jsdelivr.net/npm/@ruby/wasm-wasi@2.7.1/dist/browser/+esm";
-      const response = await fetch("/app.wasm");
+      const response = fetch("/app.wasm.gz")
+        .then(response => response.blob())
+        .then(blob => blob.stream().pipeThrough(new DecompressionStream('gzip')))
+        .then(stream => new Response(stream, { headers: { 'Content-Type': 'application/wasm' } }))
       const module = await WebAssembly.compileStreaming(response);
       const { vm } = await DefaultRubyVM(module);
 

--- a/wasm/Rakefile
+++ b/wasm/Rakefile
@@ -1,7 +1,22 @@
+require 'zlib'
+
 file '../dist/ruby.wasm' do
   system('bundle exec rbwasm build -o ../dist/ruby.wasm')
 end
 
 task :build => ['../dist/ruby.wasm'] do
   system('bundle exec rbwasm pack ../dist/ruby.wasm --dir ./src::/src -o ../dist/app.wasm')
+end
+
+task :compress do
+  input_file = '../dist/app.wasm'
+  output_file = '../dist/app.wasm.gz'
+
+  Zlib::GzipWriter.open(output_file) do |gz|
+    File.open(input_file, 'rb') do |file|
+      gz.write(file.read)
+    end
+  end
+
+  puts "Compressed #{input_file} to #{output_file}"
 end


### PR DESCRIPTION
Hi, youchan.

Thank you for your great talk at RubyKaigi 2025!
https://slide.youchan-apps.net/

However, I think the download size is too large to view the slides 😢
<img width="959" alt="スクリーンショット 2025-05-29 23 42 43" src="https://github.com/user-attachments/assets/e7ccc852-291c-45ce-9954-fdc66daca67f" />


Therefore, I've added explicit "gzip" compression/decompression processes for the wasm binary.
This should help to reduce waiting time for visitors.

----

file size:
```
51M dist/app.wasm
16M dist/app.wasm.gz
```

<img width="959" alt="スクリーンショット 2025-05-29 23 41 54" src="https://github.com/user-attachments/assets/f1cf990c-cf50-462c-9172-9f3e79d937c9" />
